### PR TITLE
Update to 6.0.0

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
+docs
 test
 
 .editorconfig

--- a/README.md
+++ b/README.md
@@ -3,7 +3,13 @@ node-cipher [![Build Status](https://travis-ci.org/nathanbuchar/node-cipher.svg?
 
 Securely encrypt sensitive files for use in public source control. [Find on NPM](https://www.npmjs.com/package/node-cipher).
 
-**Why should I use node-cipher?**
+
+**What is node-cipher?**
+
+Node-cipher is both a command line tool and a Node JS package which allows you to easily encrypt or decrypt files containing sensitive information. This way, you can safely add encrypted files to a public repository, even if they contain API keys and passwords.
+
+
+**Why would I use node-cipher?**
 
 Let's say you have a file in your project name `config.json` which contains sensitive information like private keys and database passwords. What should you do if you need to publicly host a repository containing this file? Certainly you wouldn't want to make the contents of `config.json` visible to the outside world.
 
@@ -11,189 +17,43 @@ You *could* remove the file from source control and send the file to everyone in
 
 Don't forget to add the original `config.json` file to `.gitignore`!
 
-
-***
-
-**:exclamation: If you're looking for the node-cipher command line tool, it has moved to [node-cipher-cli](http://github.com/nathanbuchar/node-cipher-cli).**
-
 ***
 
 
-Install
--------
+Installation
+------------
 
+**Command Line Interface**
+```
+$ npm install -g node-cipher
+```
+
+**Node JS**
 ```
 $ npm install node-cipher
 ```
 
 
-Options
--------
-
-|Name|Type|Description|Required|Default|
-|:---|:--:|:----------|:------:|:-----:|
-|`input`|`string`|The file that you wish to encrypt or decrypt.|✓||
-|`output`|`string`|The file that you wish to save the encrypted or decrypted contents to. This file does not necessarily need to exist beforehand.|✓||
-|`password`|`string`|The password to use when deriving the encryption key.|✓||
-|`salt`|`string`|The salt to use when deriving the encryption key.||`"nodecipher"`|
-|`iterations`|`number`|The number of iterations to use when deriving the key. The higher the number of iterations, the more secure the derived key will be, but will take a longer amount of time to complete.||`1000`|
-|`keylen`|`number`|The desired byte length for the derived key.||`512`|
-|`digest`|`string`|The HMAC digest algorithm with which to derive the key.||`"sha1"`|
-|`algorithm`|`string`|The cipher algorithm to use when encrypting or decrypting the input file. Use [`list()`](#list) to see a list of available cipher algorithms.||`"cast5-cbc"`|
-
-
-Methods
--------
-
-* [`encrypt()`](#encrypt)
-* [`encryptSync()`](#encryptsync)
-* [`decrypt()`](#decrypt)
-* [`decryptSync()`](#decryptsync)
-* [`list()`](#list)
-
 ***
 
-### encrypt()
 
-##### `encrypt(options[, callback[, scope]])`
+Documentation
+-------------
 
-Encrypts a file using the [options](#options) provided. Returns `undefined`.
+The documentation is pretty extensive, and it's split into two pieces.
 
-#### Parameters
-|Parameter|Type|Description|Required|
-|--------:|:--:|:----------|:------:|
-|`options`|`Object`|See [options](#options).|✓|
-|`callback`|`Function`|The function to call when the encryption has completed.||
-|`scope`|`Object`|The scope for the `callback` function parameter, if provided.||
+**How to use the Command Line Interface**
+[Documentation](https://github.com/nathanbuchar/node-cipher-cli/blob/master/docs/cli.md)
 
-#### Example
-
-Encrypts `config.json` into `config.json.cast5` using the password `"passw0rd"`.
-
-```js
-let nodecipher = require('node-cipher');
-
-nodecipher.encrypt({
-  input: 'config.json',
-  output: 'config.json.cast5',
-  password: 'passw0rd'
-}, function (err) {
-  if (err) throw err;
-
-  console.log('config.json encrypted.');
-});
-```
-
-***
-
-### encryptSync()
-
-##### `encryptSync(options)`
-
-The synchronous version of [`encrypt()`](#encrypt). Returns `undefined`.
-
-#### Parameters
-|Parameter|Type|Description|Required|
-|--------:|:--:|:----------|:------:|
-|`options`|`Object`|See [options](#options).|✓|
-
-#### Example
-
-Synchronously encrypts `config.json` into `config.json.cast5` using the password `"passw0rd"`.
-
-```js
-let nodecipher = require('node-cipher');
-
-nodecipher.encryptSync({
-  input: 'config.json',
-  output: 'config.json.cast5',
-  password: 'passw0rd'
-});
-```
-
-***
-
-### decrypt()
-
-##### `decrypt(options[, callback[, scope]])`
-
-Decrypts a file using the [options](#options) provided. Returns `undefined`.
-
-#### Parameters
-|Parameter|Type|Description|Required|
-|--------:|:--:|:----------|:------:|
-|`options`|`Object`|See [options](#options).|✓|
-|`callback`|`Function`|The function to call when the decryption has completed.||
-|`scope`|`Object`|The scope for the `callback` function parameter, if provided.||
-
-#### Example
-
-Decrypts `config.json.cast5` back into `config.json` using the password `"passw0rd"`.
-
-```js
-let nodecipher = require('node-cipher');
-
-nodecipher.decrypt({
-  input: 'config.json.cast5',
-  output: 'config.json',
-  password: 'passw0rd'
-}, function (err) {
-  if (err) throw err;
-
-  console.log('config.json.cast5 decrypted.');
-});
-```
-
-***
-
-### decryptSync()
-
-##### `decryptSync(options)`
-
-The synchronous version of [`decrypt()`](#decrypt).  Returns `undefined`.
-
-#### Parameters
-|Parameter|Type|Description|Required|
-|--------:|:--:|:----------|:------:|
-|`options`|`Object`|See [options](#options).|✓|
-
-#### Example
-
-Synchronously decrypts `config.json.cast5` back into `config.json` using the password `"passw0rd"`.
-
-```js
-let nodecipher = require('node-cipher');
-
-nodecipher.decryptSync({
-  input: 'config.json.cast5',
-  output: 'config.json',
-  password: 'passw0rd'
-});
-```
-
-***
-
-### list()
-
-##### `list():Array`
-
-Lists all available cipher algorithms as an Array. Returns `Array`.
-
-#### Example
-
-```js
-let nodecipher = require('node-cipher');
-
-console.log(nodecipher.list());
-// => ['CAST-cbc', 'aes-128-cbc', ..., 'seed-ofb']
-```
+**Using the Node JS API**
+[Documentation](https://github.com/nathanbuchar/node-cipher-cli/blob/master/docs/api.md)
 
 
 ***
 
 
-Debug
------
+Debugging
+---------
 
 Node-cipher implements [debug](https://github.com/visionmedia/debug) for development logging. To set up node-cipher with debug, set the following environment variables:
 

--- a/bin/actions/cipher.js
+++ b/bin/actions/cipher.js
@@ -1,0 +1,190 @@
+/**
+ * @fileoverview Handles the encrypt and decrypt commands.
+ * @author Nathan Buchar
+ */
+
+'use strict';
+
+let _ = require('lodash');
+let chalk = require('chalk');
+let inquirer = require('inquirer');
+
+let nodecipher = require('../../');
+
+/**
+ * Prompts the user to supply a password via Inquirer.
+ *
+ * @param {Function} done
+ */
+function prompForPassword(done) {
+  inquirer.prompt([{
+    type: 'password',
+    message: 'Enter the password',
+    name: 'password',
+    validate(input) {
+      return input.length > 0;
+    }
+  }], answers => {
+    done(answers.password);
+  });
+}
+
+/**
+ * Parses the command line options into a more consise Object that will be
+ * accepted by NodeCipher.
+ *
+ * @param {Object} options
+ * @returns {Object} opts;
+ */
+function parseOptions(options) {
+  let opts = {};
+
+  _.each(nodecipher.defaults, (defaultVal, name) => {
+    if (!_.isUndefined(options[name])) {
+      opts[name] = options[name];
+    }
+  });
+
+  return opts;
+}
+
+/**
+ * First checks if the password has been supplied. If not, the user is prompted
+ * to provide one. Once the password is received, parse the options and then
+ * call the appropriate NodeCipher method with the given options.
+ *
+ * @see prompForPassword
+ * @see handleCipher
+ * @param {string} command
+ * @param {string} input
+ * @param {string} output
+ * @param {Object} Options
+ */
+function cipher(command, input, output, options) {
+  if (_.isUndefined(options.password)) {
+    prompForPassword(password => {
+      cipher(command, input, output, options, _.assign(password, options));
+    });
+  } else {
+    let opts = _.assign({ input, output }, parseOptions(options));
+
+    nodecipher[command](opts, err => {
+      handleCipher(opts, err);
+    });
+  }
+}
+
+/**
+ * Called when the cipher has completed. Handles errors if there are any.
+ *
+ * @param {Object} opts
+ * @param {Error|null} err
+ */
+function handleCipher(opts, err) {
+  if (err) {
+    if (err.code === 'ENOENT') {
+      handleEnoentError(opts, err);
+    } else if (err.toString().indexOf('bad decrypt') >= 0) {
+      handleBadDecrypt(opts, err);
+    } else if (err.toString().indexOf('wrong final block length') >= 0) {
+      handleIncorrectAlgorithm(opts, err);
+    } else if (err.toString().indexOf('not a valid cipher algorithm') >= 0) {
+      handleInvalidAlgorithm(opts, err);
+    } else if (err.toString().indexOf('not a valid HMAC hash') >= 0) {
+      handleInvalidHash(opts, err);
+    } else {
+      handleUnknownErrors(opts, err);
+    }
+  } else {
+    handleCipherSuccess(opts, err);
+  }
+}
+
+/**
+ * Handles NodeCipher ENOENT errors.
+ *
+ * @param {Object} opts
+ * @param {Error} err
+ */
+function handleEnoentError(opts, err) {
+  console.log(chalk.red(
+    '\nError: ' + err.path + ' does not exist\n'
+  ));
+}
+
+/**
+ * Handles bad encryption key derivation
+ *
+ * @param {Object} opts
+ * @param {Error} err
+ */
+function handleBadDecrypt(opts, err) {
+  console.log(chalk.red(
+    '\nBad decrypt. One or more of the following may be incorrect:\n\n' +
+      '  - password\n' +
+      '  - salt\n' +
+      '  - iterations\n' +
+      '  - keylen\n' +
+      '  - digest\n'
+  ));
+}
+
+/**
+ * Handles wrong final block length (wrong algorithm).
+ *
+ * @param {Object} opts
+ * @param {Error} err
+ */
+function handleIncorrectAlgorithm(opts, err) {
+  console.log(chalk.red(
+    '\nBad decrypt. Incorrect cipher algorithm\n'
+  ));
+}
+
+/**
+ * Handles invalid cipher algorithm.
+ *
+ * @param {Object} opts
+ * @param {Error} err
+ */
+function handleInvalidAlgorithm(opts, err) {
+  console.log(chalk.red(
+    '\n' + err + ' Use `nodecipher --algorithms` to see a list of valid ' +
+    'algorithms\n'));
+}
+
+/**
+ * Handles invalid HMAC hash digest.
+ *
+ * @param {Object} opts
+ * @param {Error} err
+ */
+function handleInvalidHash(opts, err) {
+  console.log(chalk.red(
+    '\n' + err + ' Use `nodecipher --hashes` to see a list of valid HMAC ' +
+    'hashes\n'));
+}
+
+/**
+ * Handles all unknown NodeCipher errors.
+ *
+ * @param {Object} opts
+ * @param {Error} err
+ */
+function handleUnknownErrors(opts, err) {
+  throw err;
+}
+
+/**
+ * Handle encrypt/decrypt success.
+ *
+ * @param {Object} opts
+ * @param {Error} err
+ */
+function handleCipherSuccess(opts, err) {
+  console.log(chalk.green(
+    '\nSuccess: ' + opts.input + ' > ' + opts.output + '\n'
+  ));
+}
+
+module.exports = cipher;

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+
+'use strict';
+
+let _ = require('lodash');
+let program = require('commander');
+
+let Package = require('../package.json');
+let cipher = require('./actions/cipher');
+
+let nodecipher = require('../');
+
+/**
+ * Define CLI basics.
+ */
+program
+  .version(Package.version)
+  .usage('<encrypt|decrypt> <input> <output> [options]');
+
+/**
+ * Define option: -A, --algorithms
+ *
+ * This will output a list of all available cipher algorithms for use in the
+ * algorithm option.
+ */
+program.option(
+  '-A, --algorithms',
+  'output a list of all available cipher algorithms'
+);
+
+/**
+ * Define option: -H, --hashes
+ *
+ * This will output a list of all available HMAC hashes for use in the digest
+ * option.
+ */
+program.option(
+  '-H, --hashes',
+  'output a list of all available HMAC hashes'
+);
+
+/**
+ * Define encrypt and decrypt commands.
+ */
+_.each(['encrypt', 'decrypt'], command => {
+  program
+
+    /**
+     * Define command schema.
+     */
+    .command(`${command} <input> <output>`)
+
+    /**
+     * Define command decription.
+     */
+    .description(command + 's the input file using the options provided')
+
+    /**
+     * Define command alias.
+     *
+     * encrypt => enc
+     * decrypt => dec
+     */
+    .alias(command.substr(0, 3))
+
+    /**
+     * Define option: -p, --password <value>
+     *
+     * This is the password that will be used to derive the encryption key from.
+     * If the password is not provided, the user will be asked to provide one,
+     * as it is required.
+     */
+    .option(
+      '-p, --password <value>',
+      'the password that we will derive a key from'
+    )
+
+    /**
+     * Define option: -s, --salt <value>
+     *
+     * This is the salt that will be used to derive the key. By default, this is
+     * "nodecipher", however the user may choose to customize this on their own
+     * for greater security.
+     *
+     * @default "nodecipher"
+     */
+    .option(
+      '-s, --salt [value]',
+      'the salt used to derive the key'
+    )
+
+    /**
+     * Define option: -i, --iterations <n>
+     *
+     * This is the number of iterations with which to derive the encryption key.
+     * The higher the number, the more secure, but the longer it will take to
+     * process.
+     *
+     * @default 1000
+     */
+    .option(
+      '-i, --iterations [n]',
+      'the number of iterations with which to derive the key',
+      parseInt
+    )
+
+    /**
+     * Define option: -l, --keylen <n>
+     *
+     * This is the desired byte length for the derived encryption key.
+     *
+     * @default 512
+     */
+    .option(
+      '-l, --keylen [n]',
+      'the desired byte length for the derived key',
+      parseInt
+    )
+
+    /**
+     * Define option: -d, --digest <value>
+     *
+     * This is the HMAC digest algorithm to use to derive the key, combined with
+     * all the other options.
+     *
+     * @default "sha1"
+     */
+    .option(
+      '-d, --digest [value]',
+      'the HMAC digest algorithm to use to derive the key'
+    )
+
+    /**
+     * Define option: -a, --algorithm <value>
+     *
+     * This is the algorithm to use to encrypt the file with the encryption key.
+     *
+     * @default "cast5-cbc"
+     */
+    .option(
+      '-a, --algorithm [value]',
+      'the algorithm to use to encrypt the file'
+    )
+
+    /**
+     * Define command action.
+     */
+    .action((input, output, options) => {
+      cipher(command, input, output, options);
+    });
+});
+
+/**
+ * Process the provided arguments.
+ */
+program.parse(process.argv);
+
+/**
+ * Handle list algorithms.
+ */
+if (program.algorithms) {
+  console.log(nodecipher.listAlgorithms().join('\n'));
+}
+
+/**
+ * Handle list hashes.
+ */
+if (program.hashes) {
+  console.log(nodecipher.listHashes().join('\n'));
+}
+
+/**
+ * Handle no input (show help).
+ */
+if (!process.argv.slice(2).length) {
+  program.outputHelp();
+}

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,205 @@
+Node JS API Guide
+=================
+
+**Welcome!**
+
+This is the Node JS API documentation for node-cipher. Below, you'll find instructions on installation, public methods, and the options available to you.
+
+
+***
+
+
+Install
+-------
+
+```
+$ npm install node-cipher
+```
+
+
+Methods
+-------
+
+* [`encrypt()`](#encrypt)
+* [`encryptSync()`](#encryptsync)
+* [`decrypt()`](#decrypt)
+* [`decryptSync()`](#decryptsync)
+* [`listAlgorithms()`](#listalgorithms)
+* [`listHashes()`](#listhashes)
+
+***
+
+### encrypt()
+
+##### `encrypt(options[, callback[, scope]])`
+
+Encrypts a file using the [options](#options) provided. Returns `undefined`.
+
+#### Parameters
+|Parameter|Type|Description|Required|
+|--------:|:--:|:----------|:------:|
+|`options`|`Object`|See [options](#options).|✓|
+|`callback`|`Function`|The function to call when the encryption has completed.||
+|`scope`|`Object`|The scope for the `callback` function parameter, if provided.||
+
+#### Example
+
+Encrypts `config.json` into `config.json.cast5` using the password `"passw0rd"`.
+
+```js
+let nodecipher = require('node-cipher');
+
+nodecipher.encrypt({
+  input: 'config.json',
+  output: 'config.json.cast5',
+  password: 'passw0rd'
+}, function (err) {
+  if (err) throw err;
+
+  console.log('config.json encrypted.');
+});
+```
+
+***
+
+### encryptSync()
+
+##### `encryptSync(options)`
+
+The synchronous version of [`encrypt()`](#encrypt). Returns `undefined`.
+
+#### Parameters
+|Parameter|Type|Description|Required|
+|--------:|:--:|:----------|:------:|
+|`options`|`Object`|See [options](#options).|✓|
+
+#### Example
+
+Synchronously encrypts `config.json` into `config.json.cast5` using the password `"passw0rd"`.
+
+```js
+let nodecipher = require('node-cipher');
+
+nodecipher.encryptSync({
+  input: 'config.json',
+  output: 'config.json.cast5',
+  password: 'passw0rd'
+});
+```
+
+***
+
+### decrypt()
+
+##### `decrypt(options[, callback[, scope]])`
+
+Decrypts a file using the [options](#options) provided. Returns `undefined`.
+
+#### Parameters
+|Parameter|Type|Description|Required|
+|--------:|:--:|:----------|:------:|
+|`options`|`Object`|See [options](#options).|✓|
+|`callback`|`Function`|The function to call when the decryption has completed.||
+|`scope`|`Object`|The scope for the `callback` function parameter, if provided.||
+
+#### Example
+
+Decrypts `config.json.cast5` back into `config.json` using the password `"passw0rd"`.
+
+```js
+let nodecipher = require('node-cipher');
+
+nodecipher.decrypt({
+  input: 'config.json.cast5',
+  output: 'config.json',
+  password: 'passw0rd'
+}, function (err) {
+  if (err) throw err;
+
+  console.log('config.json.cast5 decrypted.');
+});
+```
+
+***
+
+### decryptSync()
+
+##### `decryptSync(options)`
+
+The synchronous version of [`decrypt()`](#decrypt).  Returns `undefined`.
+
+#### Parameters
+|Parameter|Type|Description|Required|
+|--------:|:--:|:----------|:------:|
+|`options`|`Object`|See [options](#options).|✓|
+
+#### Example
+
+Synchronously decrypts `config.json.cast5` back into `config.json` using the password `"passw0rd"`.
+
+```js
+let nodecipher = require('node-cipher');
+
+nodecipher.decryptSync({
+  input: 'config.json.cast5',
+  output: 'config.json',
+  password: 'passw0rd'
+});
+```
+
+***
+
+### listAlgorithms()
+
+##### `listAlgorithms():Array`
+
+Lists all available cipher algorithms as an Array. Returns `Array`.
+
+This is shorthand for `require('crypto').getCiphers()`.
+
+#### Example
+
+```js
+let nodecipher = require('node-cipher');
+
+console.log(nodecipher.listAlgorithms());
+// => ['CAST-cbc', 'aes-128-cbc', ..., 'seed-ofb']
+```
+
+***
+
+### listHashes()
+
+##### `listHashes():Array`
+
+Lists all available HMAC hashes as an Array. Returns `Array`.
+
+This is shorthand for `require('crypto').getHashes()`.
+
+#### Example
+
+```js
+let nodecipher = require('node-cipher');
+
+console.log(nodecipher.listHashes());
+// => ['DSA', DSA-SHA', ..., 'whirlpool']
+```
+
+
+***
+
+
+
+Options
+-------
+
+|Name|Type|Description|Required|Default|
+|:---|:--:|:----------|:------:|:-----:|
+|`input`|`string`|The file that you wish to encrypt or decrypt.|✓||
+|`output`|`string`|The file that you wish to save the encrypted or decrypted contents to. This file does not necessarily need to exist beforehand.|✓||
+|`password`|`string`|The password that we will use to derive the encryption key from.|✓||
+|`salt`|`string`|The salt to use when deriving the encryption key.||`"nodecipher"`|
+|`iterations`|`number`|The number of iterations to use when deriving the key. The higher the number of iterations, the more secure the derived key will be, but will take a longer amount of time to complete.||`1000`|
+|`keylen`|`number`|The desired byte length for the derived key.||`512`|
+|`digest`|`string`|The HMAC digest algorithm to use to derive the key. Use [`listHashes()`](#listhashes) to see a list of available HMAC hashes.||`"sha1"`|
+|`algorithm`|`string`|The cipher algorithm to use when encrypting or decrypting the input file. Use [`listAlgorithms()`](#listalgorithms) to see a list of available cipher algorithms.||`"cast5-cbc"`|

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,96 @@
+Command Line Interface Guide
+============================
+
+**Welcome!**
+
+This is the command line interface (CLI) documentation for node-cipher. Below, you'll find instructions on installation and usage.
+
+
+***
+
+
+Install
+-------
+
+```
+$ npm install -g node-cipher
+```
+
+
+Usage
+-----
+
+```
+$ nodecipher <encrypt|decrypt> <input> <output> [options]
+```
+
+When in doubt, `$ nodecipher --help`
+
+
+Commands
+--------
+
+|Command|Alias|Description|
+|:------|:---:|:----------|
+|`encrypt`|`enc`|Encrypts the input file using the options provided. See [options](#options).|
+|`decrypt`|`dec`|Decrypts the input file using the options provided. See [options](#options).|
+
+
+Options
+-----
+
+|Flag|Alias|Type|Description|Default|
+|:---|:---:|:--:|:----------|:-----:|
+|`--help`|`-h`|`boolean`|Output usage information.|
+|`--password`|`-p`|`string`|The password that we will use to derive the encryption key from. if a password is not provided by the user, they will be prompted to provide one via [inquirer](https://npmjs.org/package/inquirer).||
+|`--salt`|`-s`|`string`|The salt to use when deriving the encryption key.|`"nodecipher"`|
+|`--iterations`|`-r`|`number`|The number of iterations to use when deriving the key. The higher the number of iterations, the more secure the derived key will be, but will take a longer amount of time to complete.|`1000`|
+|`--keylen`|`-l`|`number`|The desired byte length for the derived key.|`512`|
+|`--digest`|`-d`|`string`|The HMAC digest algorithm to use to derive the key. Use `$ nodecipher --hashes` to see a list of available HMAC hashes.|`"sha1"`|
+|`--algorithm`|`-a`|`string`|The cipher algorithm to use when encrypting or decrypting the input file. Use `$ nodecipher --algorithms` to see a list of available cipher algorithms.|`cast5-cbc`|
+|`--algorithms`|`-L`|`boolean`|Outputs a list of all available cipher algorithms.|
+|`--hashes`|`-H`|`boolean`|Outputs a list of all available HMAC hashes.|
+|`--version`|`-V`|`boolean`|Output the version number.|
+
+
+Examples
+-------
+
+1. Encrypts `config.json` into `config.json.aes128` using the `aes-128-cbc` cipher algorithm.
+
+    ```bash
+    $ nodecipher encrypt "config.json" "config.json.aes128" -a "aes-128-cbc"
+    ```
+
+2. Encrypts `config.json` into `config.json.cast5` using the default algorithm and a salt of `"abrakadabra"`.
+
+    ```bash
+    $ nodecipher encrypt "config.json" "config.json.cast5" -s "abrakadabra"
+    ```
+
+3. Decrypts `config.json.cast5` back into `config.json` using the default algorithm and a salt of `"abrakadabra"`.
+
+    ```bash
+    $ nodecipher dec "config.json.cast5" "config.json" -s "abrakadabra"
+    ```
+
+
+***
+
+
+Tips
+----
+
+Using NPM, you can create custom scripts in our `package.json` file to automate much of the encryption/decryption process.
+
+```js
+{
+  // ...
+  "scripts": {
+    "encrypt": "nodecipher encrypt config.json config.json.aes128",
+    "decrypt": "nodecipher decrypt config.json.aes128 config.json"
+  }
+}
+```
+
+Simply run `$ npm run encrypt` or `$ npm run decrypt` to execute these commands.

--- a/lib/node-cipher.js
+++ b/lib/node-cipher.js
@@ -18,8 +18,15 @@ let validate = require('validate');
 
 /**
  * @const {Array} ALL_CIPHERS
+ * @see {@link https://nodejs.org/api/crypto.html#crypto_crypto_getciphers}
  */
 const ALL_CIPHERS = crypto.getCiphers();
+
+/**
+ * @const {Array} ALL_HASHES
+ * @see {@link https://nodejs.org/api/crypto.html#crypto_crypto_gethashes}
+ */
+const ALL_HASHES = crypto.getHashes();
 
 /**
  * @const {string} DEFAULT_SALT
@@ -289,6 +296,14 @@ class NodeCipher {
       });
     }
 
+    // Verify that the chosen digest is valid.
+    if (!_.includes(ALL_HASHES, options.digest)) {
+      errors.push({
+        path: 'digest',
+        message: `"${options.digest}" is not a valid HMAC hash digest.`
+      });
+    }
+
     return errors;
   }
 
@@ -316,7 +331,8 @@ class NodeCipher {
    * - decrypt()
    * - encryptSync()
    * - decryptSync()
-   * - list():Array
+   * - listAlgorithms():Array
+   * - listHashes():Array
    */
 
   /**
@@ -373,8 +389,18 @@ class NodeCipher {
    * @returns {Array}
    * @access public
    */
-  list() {
+  listAlgorithms() {
     return ALL_CIPHERS;
+  }
+
+  /**
+   * Lists all valid HMAC hashes.
+   *
+   * @returns {Array}
+   * @access public
+   */
+  listHashes() {
+    return ALL_HASHES;
   }
 
   /**
@@ -454,8 +480,6 @@ NodeCipher.Actions = {
  * @enum {string} defaults
  */
 NodeCipher.Defaults = {
-  input: undefined,
-  output: undefined,
   password: undefined,
   salt: DEFAULT_SALT, // 'nodecipher'
   iterations: DEFAULT_ITERATIONS, // 1000

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-cipher",
-  "version": "5.0.1",
+  "version": "6.0.0",
   "description": "Securely encrypt sensitive files for use in public source control.",
   "main": "index.js",
   "scripts": {
@@ -28,15 +28,23 @@
   },
   "license": "MIT",
   "dependencies": {
+    "chalk": "^1.1.1",
+    "commander": "^2.9.0",
     "debug": "^2.2.0",
     "fs-extra": "^0.26.4",
+    "inquirer": "^0.11.2",
     "lodash": "^4.0.0",
-    "validate": "^3.0.1"
+    "validate": "^3.0.1",
+    "yargs": "^3.32.0"
   },
   "devDependencies": {
     "chai": "^3.4.1",
     "mocha": "^2.3.4",
     "randomstring": "^1.1.3",
+    "shelljs": "^0.5.3",
     "tmp": "0.0.28"
+  },
+  "bin": {
+    "nodecipher": "./bin/cli.js"
   }
 }

--- a/test/api.js
+++ b/test/api.js
@@ -899,17 +899,32 @@ describe('Methods', function () {
   });
 
   /**
-   * Test specs for list().
+   * Test specs for listAlgorithms().
    *
    * - should return an array of valid algorithms
    */
-  describe('list()', function () {
+  describe('listAlgorithms()', function () {
 
     it('should return an array of valid algorithms', function () {
-      let algorithms = nodecipher.list();
+      let algorithms = nodecipher.listAlgorithms();
 
       expect(algorithms).to.be.an('array');
       expect(_.difference(algorithms, crypto.getCiphers())).to.have.length(0);
+    });
+  });
+
+  /**
+   * Test specs for listHashes().
+   *
+   * - should return an array of valid algorithms
+   */
+  describe('listHashes()', function () {
+
+    it('should return an array of valid algorithms', function () {
+      let algorithms = nodecipher.listHashes();
+
+      expect(algorithms).to.be.an('array');
+      expect(_.difference(algorithms, crypto.getHashes())).to.have.length(0);
     });
   });
 });

--- a/test/cli.js
+++ b/test/cli.js
@@ -1,0 +1,643 @@
+/**
+ * @fileoverview Mocha test specs.
+ * @author Nathan Buchar
+ */
+
+ /* globals it, describe, before, after, beforeEach, afterEach */
+ /* globals which, echo, exit, exec */
+
+'use strict';
+
+require('shelljs/global');
+
+let _ = require('lodash');
+let chai = require('chai');
+let crypto = require('crypto');
+let fs = require('fs-extra');
+let randomstring = require('randomstring');
+let tmp = require('tmp');
+
+let nodecipher = require('../');
+
+let Package = require('../package.json');
+let bin = Package.bin.nodecipher;
+
+/**
+ * Chai assertion shorthands.
+ */
+let expect = chai.expect;
+let should = chai.should();
+
+describe('Flags', function () {
+
+  /**
+   * Test specs for help.
+   *
+   * - should accept --help
+   * - should accept -h
+   */
+  describe('help', function () {
+
+    it('should accept --help', function (done) {
+      let cmd = bin + ' --help';
+
+      exec(cmd, { silent: true }, function (code, output) {
+        expect(output).to.be.a('string');
+        expect(output).to.have.length.above(0);
+        expect(output).to.not.contain('Not enough non-option arguments');
+        done();
+      });
+    });
+
+    it('should accept -h', function (done) {
+      let cmd = bin + ' -h';
+
+      exec(cmd, { silent: true }, function (code, output) {
+        expect(output).to.be.a('string');
+        expect(output).to.have.length.above(0);
+        expect(output).to.not.contain('Not enough non-option arguments');
+        done();
+      });
+    });
+  });
+
+  /**
+   * Test specs for version.
+   *
+   * - should accept --version
+   * - should accept -v
+   */
+  describe('version', function () {
+
+    it('should accept --version', function (done) {
+      let cmd = bin + ' --version';
+
+      exec(cmd, { silent: true }, function (code, output) {
+        expect(output).to.be.a('string');
+        expect(output).to.have.length.above(0);
+        expect(output).to.equal(Package.version + '\n');
+        done();
+      });
+    });
+
+    it('should accept -V', function (done) {
+      let cmd = bin + ' -V';
+
+      exec(cmd, { silent: true }, function (code, output) {
+        expect(output).to.be.a('string');
+        expect(output).to.have.length.above(0);
+        expect(output).to.equal(Package.version + '\n');
+        done();
+      });
+    });
+  });
+
+  /**
+   * Test specs for algorithms.
+   *
+   * - should accept --algorithms
+   * - should accept -A
+   */
+  describe('algorithms', function () {
+
+    it('should accept --algorithms', function (done) {
+      let cmd = bin + ' --algorithms';
+
+      exec(cmd, { silent: true }, function (code, output) {
+        expect(output).to.be.a('string');
+        expect(output).to.have.length.above(0);
+        expect(output).to.equal(crypto.getCiphers().join('\n') + '\n');
+        done();
+      });
+    });
+
+    it('should accept -A', function (done) {
+      let cmd = bin + ' -A';
+
+      exec(cmd, { silent: true }, function (code, output) {
+        expect(output).to.be.a('string');
+        expect(output).to.have.length.above(0);
+        expect(output).to.equal(crypto.getCiphers().join('\n') + '\n');
+        done();
+      });
+    });
+  });
+  /**
+   * Test specs for hashes.
+   *
+   * - should accept --hashes
+   * - should accept -H
+   */
+  describe('hashes', function () {
+
+    it('should accept --hashes', function (done) {
+      let cmd = bin + ' --hashes';
+
+      exec(cmd, { silent: true }, function (code, output) {
+        expect(output).to.be.a('string');
+        expect(output).to.have.length.above(0);
+        expect(output).to.equal(crypto.getHashes().join('\n') + '\n');
+        done();
+      });
+    });
+
+    it('should accept -H', function (done) {
+      let cmd = bin + ' -H';
+
+      exec(cmd, { silent: true }, function (code, output) {
+        expect(output).to.be.a('string');
+        expect(output).to.have.length.above(0);
+        expect(output).to.equal(crypto.getHashes().join('\n') + '\n');
+        done();
+      });
+    });
+  });
+});
+
+describe('Commands', function () {
+
+  /**
+   * Declare tmp files and content.
+   */
+  let files;
+  let content;
+
+  /**
+   * Generates a random file within our `test/tmp` directory.
+   *
+   * @returns {Object}
+   */
+  function makeRandomFileSync() {
+    return tmp.fileSync({
+      dir: 'test/.tmp',
+      prefix: 'nodecipher-',
+      postfix: '.txt'
+    });
+  }
+
+  /**
+   * Creates the `tmp` temporary directory sandbox for testing.
+   */
+  before('create tmp directory', function () {
+    fs.ensureDirSync('test/.tmp');
+  });
+
+  /**
+   * Generates all necessary temporary files for encryption.
+   */
+  beforeEach('generate temporary files', function () {
+    files = [];
+
+    for (let i = 0; i < 3; i++) {
+      files.push(makeRandomFileSync());
+    }
+  });
+
+  /**
+   * Generates the random string that we will encrypt.
+   */
+  beforeEach('generate random string', function () {
+    content = randomstring.generate();
+  });
+
+  /**
+   * Writes base content to the source file. This is what we will be encyrpting.
+   */
+  beforeEach('write to the src file', function () {
+    fs.writeFileSync(files[0].name, content);
+  });
+
+  /**
+   * Destroys all temporary files used in the previous encryption test and sets
+   * all values to null.
+   */
+  afterEach('cleanup', function () {
+    _.each(files, function (file) {
+      file.removeCallback();
+    });
+
+    files = null;
+    content = null;
+  });
+
+  /**
+   * Removes the `temp` temporary directory sandbox we used for testing.
+   */
+  after('remove tmp directory', function () {
+    fs.removeSync('test/.tmp');
+  });
+
+  /**
+   * Test specs for encrypt.
+   *
+   * - should succeed using defaults
+   * - should succeed using a custom salt
+   * - should succeed using a custom number of iterations
+   * - should succeed using a custom keylen
+   * - should succeed using a custom digest
+   * - should succeed using a custom algorithm
+   */
+  describe('encrypt', function () {
+
+    it('should succeed using defaults', function (done) {
+      let cmd = bin + ' encrypt' +
+        ' ' + files[0].name +
+        ' ' + files[1].name +
+        ' -p alakazam';
+
+      exec(cmd, { silent: true }, function (code, output) {
+        expect(output).to.be.a('string');
+        expect(output).to.have.length.above(0);
+        expect(output).to.contain('Success');
+        expect(output).to.contain(files[0].name + ' > ' + files[1].name);
+        done();
+      });
+    });
+
+    it('should succeed using a custom salt', function (done) {
+      let cmd = bin + ' encrypt' +
+        ' ' + files[0].name +
+        ' ' + files[1].name +
+        ' -p alakazam' +
+        ' -s abracadabra';
+
+      exec(cmd, { silent: true }, function (code, output) {
+        expect(output).to.be.a('string');
+        expect(output).to.have.length.above(0);
+        expect(output).to.contain('Success');
+        expect(output).to.contain(files[0].name + ' > ' + files[1].name);
+        done();
+      });
+    });
+
+    it('should succeed using a custom number of iterations', function (done) {
+      let cmd = bin + ' encrypt' +
+        ' ' + files[0].name +
+        ' ' + files[1].name +
+        ' -p alakazam' +
+        ' -i 500';
+
+      exec(cmd, { silent: true }, function (code, output) {
+        expect(output).to.be.a('string');
+        expect(output).to.have.length.above(0);
+        expect(output).to.contain('Success');
+        expect(output).to.contain(files[0].name + ' > ' + files[1].name);
+        done();
+      });
+    });
+
+    it('should succeed using a custom keylen', function (done) {
+      let cmd = bin + ' encrypt' +
+        ' ' + files[0].name +
+        ' ' + files[1].name +
+        ' -p alakazam' +
+        ' -l 256';
+
+      exec(cmd, { silent: true }, function (code, output) {
+        expect(output).to.be.a('string');
+        expect(output).to.have.length.above(0);
+        expect(output).to.contain('Success');
+        expect(output).to.contain(files[0].name + ' > ' + files[1].name);
+        done();
+      });
+    });
+
+    it('should succeed using a custom digest', function (done) {
+      let cmd = bin + ' encrypt' +
+        ' ' + files[0].name +
+        ' ' + files[1].name +
+        ' -p alakazam' +
+        ' -d sha256';
+
+      exec(cmd, { silent: true }, function (code, output) {
+        expect(output).to.be.a('string');
+        expect(output).to.have.length.above(0);
+        expect(output).to.contain('Success');
+        expect(output).to.contain(files[0].name + ' > ' + files[1].name);
+        done();
+      });
+    });
+
+    it('should succeed using a custom algorithm', function (done) {
+      let cmd = bin + ' encrypt' +
+        ' ' + files[0].name +
+        ' ' + files[1].name +
+        ' -p alakazam' +
+        ' -a aes-128-cbc';
+
+      exec(cmd, { silent: true }, function (code, output) {
+        expect(output).to.be.a('string');
+        expect(output).to.have.length.above(0);
+        expect(output).to.contain('Success');
+        expect(output).to.contain(files[0].name + ' > ' + files[1].name);
+        done();
+      });
+    });
+  });
+
+  /**
+   * Test specs for decrypt.
+   *
+   * - should succeed using defaults
+   * - should succeed using a custom salt
+   * - should succeed using a custom numberof iterations
+   * - should succeed using a custom keylen
+   * - should succeed using a custom digest
+   * - should succeed using a custom algorithm
+   * - should fail when using the wrong password
+   * - should fail when using the wrong salt
+   * - should fail when using the wrong number of iterations
+   * - should fail when using the wrong keylen
+   * - should fail when using the wrong digest
+   * - should fail when using the wrong algorithm
+   * - should fail if the input file does not exist
+   */
+  describe('decrypt', function () {
+
+    /**
+     * Creates the encrypted file that we will test our decrypt methods on.
+     */
+    beforeEach('create the encrypted file', function () {
+      nodecipher.encryptSync({
+        input: files[0].name,
+        output: files[1].name,
+        password: 'alakazam'
+      });
+    });
+
+    it('should succeed using defaults', function (done) {
+      let cmd = bin + ' decrypt' +
+        ' ' + files[1].name +
+        ' ' + files[2].name +
+        ' -p alakazam';
+
+      exec(cmd, { silent: true }, function (code, output) {
+        expect(output).to.be.a('string');
+        expect(output).to.have.length.above(0);
+        expect(output).to.contain('Success');
+        expect(output).to.contain(files[1].name + ' > ' + files[2].name);
+
+        fs.readFile(files[2].name, 'utf8', function (err, data) {
+          should.not.exist(err);
+          expect(data).to.equal(content);
+          done();
+        });
+      });
+    });
+
+    it('should succeed using a custom salt', function (done) {
+      let cmd = bin + ' decrypt' +
+        ' ' + files[1].name +
+        ' ' + files[2].name +
+        ' -p alakazam' +
+        ' -s abracadabra';
+
+      // Overwrite the encrypted file using a custom algorithm.
+      nodecipher.encryptSync({
+        input: files[0].name,
+        output: files[1].name,
+        password: 'alakazam',
+        salt: 'abracadabra'
+      });
+
+      exec(cmd, { silent: true }, function (code, output) {
+        expect(output).to.be.a('string');
+        expect(output).to.have.length.above(0);
+        expect(output).to.contain('Success');
+        expect(output).to.contain(files[1].name + ' > ' + files[2].name);
+
+        fs.readFile(files[2].name, 'utf8', function (err, data) {
+          should.not.exist(err);
+          expect(data).to.equal(content);
+          done();
+        });
+      });
+    });
+
+    it('should succeed using a custom number of iterations', function (done) {
+      let cmd = bin + ' decrypt' +
+        ' ' + files[1].name +
+        ' ' + files[2].name +
+        ' -p alakazam' +
+        ' -i 500';
+
+      // Overwrite the encrypted file using a custom algorithm.
+      nodecipher.encryptSync({
+        input: files[0].name,
+        output: files[1].name,
+        password: 'alakazam',
+        iterations: 500
+      });
+
+      exec(cmd, { silent: true }, function (code, output) {
+        expect(output).to.be.a('string');
+        expect(output).to.have.length.above(0);
+        expect(output).to.contain('Success');
+        expect(output).to.contain(files[1].name + ' > ' + files[2].name);
+
+        fs.readFile(files[2].name, 'utf8', function (err, data) {
+          should.not.exist(err);
+          expect(data).to.equal(content);
+          done();
+        });
+      });
+    });
+
+    it('should succeed using a custom keylen', function (done) {
+      let cmd = bin + ' decrypt' +
+        ' ' + files[1].name +
+        ' ' + files[2].name +
+        ' -p alakazam' +
+        ' -l 256';
+
+      // Overwrite the encrypted file using a custom algorithm.
+      nodecipher.encryptSync({
+        input: files[0].name,
+        output: files[1].name,
+        password: 'alakazam',
+        keylen: 256
+      });
+
+      exec(cmd, { silent: true }, function (code, output) {
+        expect(output).to.be.a('string');
+        expect(output).to.have.length.above(0);
+        expect(output).to.contain('Success');
+        expect(output).to.contain(files[1].name + ' > ' + files[2].name);
+
+        fs.readFile(files[2].name, 'utf8', function (err, data) {
+          should.not.exist(err);
+          expect(data).to.equal(content);
+          done();
+        });
+      });
+    });
+
+    it('should succeed using a custom digest', function (done) {
+      let cmd = bin + ' decrypt' +
+        ' ' + files[1].name +
+        ' ' + files[2].name +
+        ' -p alakazam' +
+        ' -d sha256';
+
+      // Overwrite the encrypted file using a custom algorithm.
+      nodecipher.encryptSync({
+        input: files[0].name,
+        output: files[1].name,
+        password: 'alakazam',
+        digest: 'sha256'
+      });
+
+      exec(cmd, { silent: true }, function (code, output) {
+        expect(output).to.be.a('string');
+        expect(output).to.have.length.above(0);
+        expect(output).to.contain('Success');
+        expect(output).to.contain(files[1].name + ' > ' + files[2].name);
+
+        fs.readFile(files[2].name, 'utf8', function (err, data) {
+          should.not.exist(err);
+          expect(data).to.equal(content);
+          done();
+        });
+      });
+    });
+
+    it('should succeed using a custom algorithm', function (done) {
+      let cmd = bin + ' decrypt' +
+        ' ' + files[1].name +
+        ' ' + files[2].name +
+        ' -p alakazam' +
+        ' -a aes-128-cbc';
+
+      // Overwrite the encrypted file using a custom algorithm.
+      nodecipher.encryptSync({
+        input: files[0].name,
+        output: files[1].name,
+        password: 'alakazam',
+        algorithm: 'aes-128-cbc'
+      });
+
+      exec(cmd, { silent: true }, function (code, output) {
+        expect(output).to.be.a('string');
+        expect(output).to.have.length.above(0);
+        expect(output).to.contain('Success');
+        expect(output).to.contain(files[1].name + ' > ' + files[2].name);
+
+        fs.readFile(files[2].name, 'utf8', function (err, data) {
+          should.not.exist(err);
+          expect(data).to.equal(content);
+          done();
+        });
+      });
+    });
+
+    it('should fail when using the wrong password', function (done) {
+      let cmd = bin + ' decrypt' +
+        ' ' + files[1].name +
+        ' ' + files[2].name +
+        ' -p not-alakazam';
+
+      exec(cmd, { silent: true }, function (code, output) {
+        expect(output).to.be.a('string');
+        expect(output).to.have.length.above(0);
+        expect(output).to.contain('Bad decrypt');
+        expect(output).to.contain('password');
+        done();
+      });
+    });
+
+    it('should fail when using the wrong salt', function (done) {
+      let cmd = bin + ' decrypt' +
+        ' ' + files[1].name +
+        ' ' + files[2].name +
+        ' -p alakazam ' +
+        ' -s wrongsalt';
+
+      exec(cmd, { silent: true }, function (code, output) {
+        expect(output).to.be.a('string');
+        expect(output).to.have.length.above(0);
+        expect(output).to.contain('Bad decrypt');
+        expect(output).to.contain('salt');
+        done();
+      });
+    });
+
+    it('should fail when using the wrong number of iterations', function (done) {
+      let cmd = bin + ' decrypt' +
+        ' ' + files[1].name +
+        ' ' + files[2].name +
+        ' -p alakazam ' +
+        ' -i 1001';
+
+      exec(cmd, { silent: true }, function (code, output) {
+        expect(output).to.be.a('string');
+        expect(output).to.have.length.above(0);
+        expect(output).to.contain('Bad decrypt');
+        expect(output).to.contain('iterations');
+        done();
+      });
+    });
+
+    it('should fail when using the wrong keylen', function (done) {
+      let cmd = bin + ' decrypt' +
+        ' ' + files[1].name +
+        ' ' + files[2].name +
+        ' -p alakazam ' +
+        ' -l 256';
+
+      exec(cmd, { silent: true }, function (code, output) {
+        expect(output).to.be.a('string');
+        expect(output).to.have.length.above(0);
+        expect(output).to.contain('Bad decrypt');
+        expect(output).to.contain('keylen');
+        done();
+      });
+    });
+
+    it('should fail when using the wrong digest', function (done) {
+      let cmd = bin + ' decrypt' +
+        ' ' + files[1].name +
+        ' ' + files[2].name +
+        ' -p alakazam ' +
+        ' -d sha256';
+
+      exec(cmd, { silent: true }, function (code, output) {
+        expect(output).to.be.a('string');
+        expect(output).to.have.length.above(0);
+        expect(output).to.contain('Bad decrypt');
+        expect(output).to.contain('digest');
+        done();
+      });
+    });
+
+    it('should fail when using the wrong algorithm', function (done) {
+      let cmd = bin + ' decrypt' +
+        ' ' + files[1].name +
+        ' ' + files[2].name +
+        ' -p alakazam ' +
+        ' -a aes-128-cbc';
+
+      exec(cmd, { silent: true }, function (code, output) {
+        expect(output).to.be.a('string');
+        expect(output).to.have.length.above(0);
+        expect(output).to.contain('Bad decrypt');
+        expect(output).to.contain('algorithm');
+        done();
+      });
+    });
+
+    it('should fail if the input file does not exist', function (done) {
+      let cmd = bin + ' decrypt ' +
+        ' ' + 'notarealfile.txt' +
+        ' ' + files[2].name +
+        ' -p alakazam';
+
+      exec(cmd, { silent: true }, function (code, output) {
+        expect(output).to.be.a('string');
+        expect(output).to.have.length.above(0);
+        expect(output).to.contain('Error');
+        expect(output).to.contain('does not exist');
+        done();
+      });
+    });
+  });
+});


### PR DESCRIPTION
- Move the command line interface within the core node-cipher package.
- Split README into two pieces: one for the CLI, and the other for the Node JS API.
- Change `list()` to `listAlgorithms()`.
- add `listHashes()` public method to list all available HMAC hashes.
- Update tests to include these new methods.
- The CLI no longer accepts the input and output as options, but rather as arguments.
- The `--iterations` shorthand has been changed to `-i`
- Added tests to reflect the recent CLI changes.
- CLI is now using commander instead of yargs.
- Rewritten and more robust CLI code.
- Changed `--list` option to `--algorithms`.
- Added `--hashes` option.
- Added `enc` and `dec` aliases for `encrypt` and `decrypt` respectively.
