### PR TITLE
Add non-zero exit code when errors occur

### DIFF
--- a/bin/actions/cipher.js
+++ b/bin/actions/cipher.js
@@ -100,7 +100,7 @@ function handleCipher(opts, err) {
       default:
         handleUnknownErrors(opts, err);
     }
-    exit(1);
+    process.exit(1);
   } else {
     handleCipherSuccess(opts, err);
   }

--- a/bin/actions/cipher.js
+++ b/bin/actions/cipher.js
@@ -100,6 +100,7 @@ function handleCipher(opts, err) {
       default:
         handleUnknownErrors(opts, err);
     }
+    exit(1);
   } else {
     handleCipherSuccess(opts, err);
   }


### PR DESCRIPTION
Add a non-zero error code when errors occur in order to combine the node-cipher CLI with other bash scripts.